### PR TITLE
Only show topbar backbutton if a backstack is available

### DIFF
--- a/CodeHub/Services/NavigationService.cs
+++ b/CodeHub/Services/NavigationService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -13,6 +14,23 @@ namespace CodeHub.Services
         public NavigationService(Frame mainFrame)
         {
             _mainFrame = mainFrame;
+            _mainFrame.Navigated += OnMainFrameNavigated;
+        }
+
+        private void OnMainFrameNavigated(object sender, NavigationEventArgs navigationEventArgs)
+        {
+            if (_mainFrame.CanGoBack)
+            {
+                // Show UI in title bar if opted-in and in-app backstack is not empty.
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
+                    AppViewBackButtonVisibility.Visible;
+            }
+            else
+            {
+                // Remove the UI from the title bar if in-app back stack is empty.
+                SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility =
+                    AppViewBackButtonVisibility.Collapsed;
+            }
         }
 
         private Frame _mainFrame;

--- a/CodeHub/Views/MainPage.xaml.cs
+++ b/CodeHub/Views/MainPage.xaml.cs
@@ -51,7 +51,6 @@ namespace CodeHub.Views
             }
 
             SystemNavigationManager.GetForCurrentView().BackRequested += SystemNavigationManager_BackRequested;
-            SystemNavigationManager.GetForCurrentView().AppViewBackButtonVisibility = AppViewBackButtonVisibility.Visible;
         }
         private void SystemNavigationManager_BackRequested(object sender, BackRequestedEventArgs e)
         {


### PR DESCRIPTION
When we arrive on the mainpage we already see the back button ( arrow ) available in the top appbar.
This should only be available if there is a backstack.